### PR TITLE
Fix filter reset on navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,8 +402,14 @@
                     e.target.classList.add('nav-link-active');
                     e.target.classList.remove('nav-link-inactive');
 
-                    if (targetId === 'eat') displayContent(targetId, 'all', eatContent, 'Eat');
-                    if (targetId === 'seeDo') displayContent(targetId, 'all', seeDoContent, 'See & Do');
+                    if (targetId === 'eat') {
+                        displayContent(targetId, 'all', eatContent, 'Eat');
+                        updateNavLinks(eatSubNav, eatSubNav.querySelector('button[data-subtarget="all"]'));
+                    }
+                    if (targetId === 'seeDo') {
+                        displayContent(targetId, 'all', seeDoContent, 'See & Do');
+                        updateNavLinks(seeDoSubNav, seeDoSubNav.querySelector('button[data-subtarget="all"]'));
+                    }
                     if (targetId === 'stay') displayContent(targetId, 'all', stayContent, 'Stay');
                 }
             });


### PR DESCRIPTION
## Summary
- ensure 'Eat' and 'See & Do' tabs reset their subfilters when selected

## Testing
- `tidy -errors -q index.html`

------
https://chatgpt.com/codex/tasks/task_e_684a14f22d2c8320a3df6c9f7de11fb5